### PR TITLE
[Windows] Install qxmpp shared library next to exe file.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,15 @@ file(GLOB_RECURSE qxmpp_h src/QXmpp*.h)
 
 add_definitions(-DQXMPP_BUILD)
 include_directories(src/base src/client)
-add_library(qxmpp SHARED ${qxmpp_cpp} ${qxmpp_h})
+add_library(${PROJECT_NAME} SHARED ${qxmpp_cpp} ${qxmpp_h})
+
+if(INSTALL_QXMPP AND WIN32)
+	foreach(CONFIGURATION Debug Release)
+		install(FILES 			${CMAKE_CURRENT_BINARY_DIR}/${CONFIGURATION}/${PROJECT_NAME}.dll 
+				CONFIGURATIONS 	${CONFIGURATION}
+				DESTINATION 	${BIN_INSTALL_DIR})
+	endforeach()
+endif(INSTALL_QXMPP AND WIN32)
 
 target_link_libraries(qxmpp Qt5::Core Qt5::Xml Qt5::Network)
 ################################################################################


### PR DESCRIPTION
This will install qxmpp.dll into ${BIN_INSTALL_DIR} that set in parent cmake project as path next to main executable.
